### PR TITLE
Give the headers more space

### DIFF
--- a/layouts/partials/css/main.css
+++ b/layouts/partials/css/main.css
@@ -107,6 +107,7 @@ th {
 
 #content {
     padding: 15px;
+    padding-top: 40px;
 }
 
 #content a {


### PR DESCRIPTION
Content pages had the menu close to the text, this adds extra spacing for this.