### PR TITLE
Give all headers more space

### DIFF
--- a/layouts/partials/css/main.css
+++ b/layouts/partials/css/main.css
@@ -6,6 +6,10 @@ pre {
     font-family: monospace;
 }
 
+h1, h2, h3, h4, h5, h6, h6 {
+    margin-top: 1em;
+}
+
 #header {
     height: 300px;
     background: rgba(0,0,0,1.0) url("/img/header.jpg") no-repeat center;


### PR DESCRIPTION
Alternative is to use the padding, but this would leave all the lines intact. This should keep resizing pages to look nice. 1em is a standard line, so this is half a line of extra space.