### PR TITLE
Ensure link to cutive.css is absolute

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -7,10 +7,10 @@
     <title>{{ block "title" . }}{{ .Site.Title }} {{ with .Params.Title }} | {{ . }}{{ end }}{{ end }}</title>
     <meta name="HandheldFriendly" content="True">
     <meta name="MobileOptimized" content="320">
-    <!--<link rel="stylesheet" crossorigin="anonymous" href='{{ "css/cutive.css" | absLangURL }}' integrity="sha384-ju5MqV+ZiL8dg/RhHnKLpFZayQjdqLmc1ZD8iXY/PfHfuTazeKld9ydWIB1SFCUd">-->
+    <!--<link rel="stylesheet" crossorigin="anonymous" href='{{ "/css/cutive.css" | absLangURL }}' integrity="sha384-ju5MqV+ZiL8dg/RhHnKLpFZayQjdqLmc1ZD8iXY/PfHfuTazeKld9ydWIB1SFCUd">-->
     <!-- href="https://fonts.googleapis.com/css?family=Cutive+Mono" -->
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
-    <link rel="stylesheet" crossorigin="anonymous" href="css/cutive.css" integrity="sha384-ju5MqV+ZiL8dg/RhHnKLpFZayQjdqLmc1ZD8iXY/PfHfuTazeKld9ydWIB1SFCUd">
+    <link rel="stylesheet" crossorigin="anonymous" href="/css/cutive.css" integrity="sha384-ju5MqV+ZiL8dg/RhHnKLpFZayQjdqLmc1ZD8iXY/PfHfuTazeKld9ydWIB1SFCUd">
     <style media="screen">
       {{ partial "css/main.css" . | safeCSS }}
     </style>


### PR DESCRIPTION
Because there is not leading slash in the relative link to cutive css, cutive.css fails to load on most pages